### PR TITLE
Improve Base64 endpoint: error handling, JSON, GET support, URL-safe/no-pad options, tests, and UI tweaks

### DIFF
--- a/.github/ISSUE_DRAFT_UTILITIES.md
+++ b/.github/ISSUE_DRAFT_UTILITIES.md
@@ -1,0 +1,27 @@
+# Utility Ideas for /utils
+
+This issue tracks proposed additions to the Utilities section. Each item can be split into its own issue/PR.
+
+## Quick Wins (stdlib-only)
+- URL Encoder/Decoder (`net/url`): `/utils/url/{encode,decode}`
+- Hash Generator (MD5/SHA-1/SHA-256): `/utils/hash`
+- HMAC Generator (HMAC-SHA256): `/utils/hmac`
+- JWT Decoder (optional verify): `/utils/jwt`
+- Timestamp Converter (Unix ↔ RFC3339): `/utils/time`
+- JSON Tools (pretty/minify/validate): `/utils/json`
+- CSV → JSON (paste/upload): `/utils/csv`
+- Slugify: `/utils/slugify`
+- HTML Escape/Unescape: `/utils/html`
+- Random Password/Token (CSPRNG): `/utils/random`
+
+## Networking/Systems
+- DNS Lookup (A/AAAA/CNAME/MX): `/utils/dns`
+- CIDR Calculator: `/utils/cidr`
+
+## Optional (adds deps)
+- UUID v4 Generator: `/utils/uuid` (dep: github.com/google/uuid)
+- QR Code Generator: `/utils/qrcode` (dep: github.com/skip2/go-qrcode)
+
+## Notes
+- Pattern: add templates under `templates/utils/<tool>/`, handlers in `controllers/`, routes in `cmd/bob/bob.go`, render via `views.ParseFS(templates.FS, ..., "base.gohtml").`
+- Add links on `/utils` and include CSRF field for forms.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `cmd/bob/`: application entrypoint (`main` package).
+- `controllers/`: HTTP handlers grouped by feature (e.g., `blog`, `utils`).
+- `models/`: services, data types, and config loading.
+- `views/`: template execution helpers and shared funcs.
+- `templates/`: HTML templates (`.gohtml`) embedded via `templates.FS`.
+- `posts/`: markdown posts (embedded via `posts.FS`), named by slug (e.g., `my-post.md`).
+- `static/`: public assets (images, compiled CSS, JS).
+- `tailwind/`: Tailwind source and config.
+
+## Build, Test, and Development Commands
+- `make local`: runs Tailwind watcher and Air for live reload.
+- `make run`: starts the app via Air (`.air.toml` builds `./cmd/bob`).
+- `make tail-watch` / `make tail-prod`: generate CSS (watch/minified).
+- `make docker-build` / `make docker-push`: build and push `drywaters/bob` image.
+- Manual build: `go build -o ./tmp/bob ./cmd/bob`.
+
+Prereqs: Go 1.22+, `air`, `tailwindcss` on PATH. Copy `.env.template` to `.env`.
+
+## Coding Style & Naming Conventions
+- Go formatting: run `gofmt` (tabs, 1TBS braces). Prefer `go vet` before PRs.
+- Packages: lowercase, short; files use underscores (e.g., `base64.go`).
+- Exported identifiers: `CamelCase`; unexported: `camelCase`/`lowercase`.
+- Templates: `.gohtml`; group by category (e.g., `utils/base64/encode.gohtml`).
+- Routes: register in `cmd/bob/bob.go`; keep handlers in `controllers/`.
+
+## Testing Guidelines
+- Framework: Go standard testing. Place tests as `*_test.go` beside code.
+- Run tests: `go test ./...` (add `-cover` for coverage).
+- Table-driven tests for services in `models/`; minimal handler tests for controllers.
+
+## Commit & Pull Request Guidelines
+- Commits: short, imperative, scoped (e.g., “Fix embed posts”, “Remove chi”).
+- PRs: clear description, linked issues, and screenshots for UI changes.
+- Include: what/why, testing notes, relevant commands (e.g., `make tail-prod`).
+
+## Security & Configuration
+- `.env`: set `SERVER_ADDRESS`, `CSRF_KEY`, `CSRF_SECURE`.
+- Use a 32-byte random `CSRF_KEY`; never commit secrets.
+- Static files served from `/static/`; templates and posts are embedded at build time.
+
+## Adding Content
+- New post: create `posts/<slug>.md` with TOML front matter (`title`, `slug`, `author`).
+- New page: add template under `templates/<section>/`, wire route in `bob.go`, render via `views.ParseFS`.

--- a/cmd/bob/bob.go
+++ b/cmd/bob/bob.go
@@ -54,8 +54,12 @@ func run(cfg models.Config) error {
 		Templates: controllers.UtilsTemplates{
 			Index: views.Must(views.ParseFS(templates.FS, "utils/index.gohtml", "base.gohtml")),
 			Base64: controllers.Base64Templates{
-				Base64Response: views.Must(views.ParseFS(templates.FS, "utils/base64/base64_response.gohtml")),
+				Base64EncodeResponse: views.Must(views.ParseFS(templates.FS, "utils/base64/base64_response_encode.gohtml")),
+				Base64DecodeResponse: views.Must(views.ParseFS(templates.FS, "utils/base64/base64_response_decode.gohtml")),
+				Base64Error:          views.Must(views.ParseFS(templates.FS, "utils/base64/base64_error.gohtml")),
 			},
+			Base64EncodePage: views.Must(views.ParseFS(templates.FS, "utils/base64/encode.gohtml", "base.gohtml")),
+			Base64DecodePage: views.Must(views.ParseFS(templates.FS, "utils/base64/decode.gohtml", "base.gohtml")),
 		},
 	}
 
@@ -69,11 +73,9 @@ func run(cfg models.Config) error {
 	r.HandleFunc("GET /utils", utilsController.Index)
 
 	// Base64 Utils
-	r.HandleFunc("GET /utils/base64/encode", controllers.StaticHandler(
-		views.Must(views.ParseFS(templates.FS, "utils/base64/encode.gohtml", "base.gohtml"))))
+	r.HandleFunc("GET /utils/base64/encode", utilsController.EncodeGET)
 	r.HandleFunc("POST /utils/base64/encode", utilsController.Encode)
-	r.HandleFunc("GET /utils/base64/decode", controllers.StaticHandler(
-		views.Must(views.ParseFS(templates.FS, "utils/base64/decode.gohtml", "base.gohtml"))))
+	r.HandleFunc("GET /utils/base64/decode", utilsController.DecodeGET)
 	r.HandleFunc("POST /utils/base64/decode", utilsController.Decode)
 
 	// Blog

--- a/controllers/base64.go
+++ b/controllers/base64.go
@@ -1,38 +1,83 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/DryWaters/bitofbytes/views"
 )
 
+const maxBase64InputLen = 1024
+
 type Base64Templates struct {
-	Base64Response views.Page
+	Base64EncodeResponse views.Page
+	Base64DecodeResponse views.Page
+	Base64Error          views.Page
 }
 
 func (u *Utils) Encode(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "text/html")
-	encoded := u.Base64Service.Encode([]byte(r.PostFormValue("str")))
-	e := struct {
-		Response string
-	}{
-		Response: encoded,
+	in := r.PostFormValue("str")
+	urlSafe := r.PostFormValue("urlSafe") != ""
+	noPad := r.PostFormValue("noPad") != ""
+	if len(in) > maxBase64InputLen {
+		if strings.Contains(r.Header.Get("Accept"), "application/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			json.NewEncoder(w).Encode(map[string]string{"error": "input too long", "message": "Input too long (max 1024 chars)"})
+		} else {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			u.Templates.Base64.Base64Error.Execute(w, r, struct{ Error string }{Error: "Input too long (max 1024 chars)"})
+		}
+		return
 	}
-	u.Templates.Base64.Base64Response.Execute(w, r, e)
+	encoded := u.Base64Service.EncodeWith([]byte(in), urlSafe, noPad)
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"result": encoded})
+		return
+	}
+	e := struct{ Response string }{Response: encoded}
+	u.Templates.Base64.Base64EncodeResponse.Execute(w, r, e)
 }
 
 func (u *Utils) Decode(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "text/html")
 
-	str, err := u.Base64Service.Decode([]byte(r.PostFormValue("str")))
-	if err != nil {
-		http.Error(w, "unable to decode string", http.StatusBadRequest)
+	in := r.PostFormValue("str")
+	urlSafe := r.PostFormValue("urlSafe") != ""
+	noPad := r.PostFormValue("noPad") != ""
+	if len(in) > maxBase64InputLen {
+		if strings.Contains(r.Header.Get("Accept"), "application/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			json.NewEncoder(w).Encode(map[string]string{"error": "input too long", "message": "Input too long (max 1024 chars)"})
+		} else {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			u.Templates.Base64.Base64Error.Execute(w, r, struct{ Error string }{Error: "Input too long (max 1024 chars)"})
+		}
+		return
 	}
 
-	d := struct {
-		Response string
-	}{
-		Response: str,
+	str, err := u.Base64Service.DecodeWith([]byte(in), urlSafe, noPad)
+	if err != nil {
+		if strings.Contains(r.Header.Get("Accept"), "application/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "unable to decode", "message": "Unable to decode string"})
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+			u.Templates.Base64.Base64Error.Execute(w, r, struct{ Error string }{Error: "Unable to decode string"})
+		}
+		return
 	}
-	u.Templates.Base64.Base64Response.Execute(w, r, d)
+
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"result": str})
+		return
+	}
+	d := struct{ Response string }{Response: str}
+	u.Templates.Base64.Base64DecodeResponse.Execute(w, r, d)
 }

--- a/controllers/base64_test.go
+++ b/controllers/base64_test.go
@@ -1,0 +1,88 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestEncode_JSON(t *testing.T) {
+	u := Utils{}
+	form := url.Values{"str": {"hi"}}
+	r := httptest.NewRequest(http.MethodPost, "/utils/base64/encode", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	u.Encode(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if body["result"] != "aGk=" {
+		t.Fatalf("result = %q", body["result"])
+	}
+}
+
+func TestDecode_JSON_Invalid(t *testing.T) {
+	u := Utils{}
+	form := url.Values{"str": {"!!!!"}}
+	r := httptest.NewRequest(http.MethodPost, "/utils/base64/decode", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	u.Decode(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if body["error"] == "" {
+		t.Fatalf("expected error in body")
+	}
+}
+
+func TestEncodeGET_Query_JSON(t *testing.T) {
+	u := Utils{}
+	r := httptest.NewRequest(http.MethodGet, "/utils/base64/encode?q=hi", nil)
+	r.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	u.EncodeGET(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if body["result"] != "aGk=" {
+		t.Fatalf("result = %q", body["result"])
+	}
+}
+
+func TestDecodeGET_Query_TooLong(t *testing.T) {
+	u := Utils{}
+	long := strings.Repeat("a", maxBase64InputLen+1)
+	r := httptest.NewRequest(http.MethodGet, "/utils/base64/decode?q="+long, nil)
+	r.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	u.DecodeGET(w, r)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d", w.Code)
+	}
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,7 +1,9 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/DryWaters/bitofbytes/models"
 	"github.com/DryWaters/bitofbytes/views"
@@ -13,10 +15,102 @@ type Utils struct {
 }
 
 type UtilsTemplates struct {
-	Index  views.Page
-	Base64 Base64Templates
+	Index            views.Page
+	Base64           Base64Templates
+	Base64EncodePage views.Page
+	Base64DecodePage views.Page
 }
 
 func (u *Utils) Index(w http.ResponseWriter, r *http.Request) {
 	u.Templates.Index.Execute(w, r, nil)
+}
+
+// EncodeGET serves the encode page by default, or returns an encoded result
+// when the query parameter `q` is provided.
+func (u *Utils) EncodeGET(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		u.Templates.Base64EncodePage.Execute(w, r, nil)
+		return
+	}
+
+	if len(q) > maxBase64InputLen {
+		if strings.Contains(r.Header.Get("Accept"), "application/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			json.NewEncoder(w).Encode(map[string]string{"error": "input too long", "message": "Input too long (max 1024 chars)"})
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		w.Write([]byte("Input too long (max 1024 chars)"))
+		return
+	}
+
+	urlSafe := parseBool(r.URL.Query().Get("urlSafe"))
+	noPad := parseBool(r.URL.Query().Get("noPad"))
+	res := u.Base64Service.EncodeWith([]byte(q), urlSafe, noPad)
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"result": res})
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte(res))
+}
+
+// DecodeGET serves the decode page by default, or returns a decoded result
+// when the query parameter `q` is provided.
+func (u *Utils) DecodeGET(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	if q == "" {
+		u.Templates.Base64DecodePage.Execute(w, r, nil)
+		return
+	}
+
+	if len(q) > maxBase64InputLen {
+		if strings.Contains(r.Header.Get("Accept"), "application/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			json.NewEncoder(w).Encode(map[string]string{"error": "input too long", "message": "Input too long (max 1024 chars)"})
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		w.Write([]byte("Input too long (max 1024 chars)"))
+		return
+	}
+
+	urlSafe := parseBool(r.URL.Query().Get("urlSafe"))
+	noPad := parseBool(r.URL.Query().Get("noPad"))
+	str, err := u.Base64Service.DecodeWith([]byte(q), urlSafe, noPad)
+	if err != nil {
+		if strings.Contains(r.Header.Get("Accept"), "application/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "unable to decode", "message": "Unable to decode string"})
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Unable to decode string"))
+		return
+	}
+
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"result": str})
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte(str))
+}
+
+func parseBool(v string) bool {
+	switch strings.ToLower(v) {
+	case "1", "true", "on", "yes":
+		return true
+	default:
+		return false
+	}
 }

--- a/models/base64.go
+++ b/models/base64.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"bytes"
 	"encoding/base64"
 )
 
@@ -11,10 +12,46 @@ func (s *Base64Service) Encode(b []byte) string {
 	return base64.StdEncoding.EncodeToString(b)
 }
 
+// EncodeWith encodes using URL-safe and/or no-padding variants when requested.
+func (s *Base64Service) EncodeWith(b []byte, urlSafe, noPad bool) string {
+	var enc *base64.Encoding
+	switch {
+	case urlSafe && noPad:
+		enc = base64.RawURLEncoding
+	case urlSafe && !noPad:
+		enc = base64.URLEncoding
+	case !urlSafe && noPad:
+		enc = base64.RawStdEncoding
+	default:
+		enc = base64.StdEncoding
+	}
+	return enc.EncodeToString(b)
+}
+
 func (s *Base64Service) Decode(b []byte) (string, error) {
-	dst := make([]byte, len(b))
+	src := bytes.TrimSpace(b)
+	dst := make([]byte, base64.StdEncoding.DecodedLen(len(src)))
 
-	n, err := base64.StdEncoding.Decode(dst, b)
+	n, err := base64.StdEncoding.Decode(dst, src)
 
+	return string(dst[:n]), err
+}
+
+// DecodeWith decodes using URL-safe and/or no-padding variants when requested.
+func (s *Base64Service) DecodeWith(b []byte, urlSafe, noPad bool) (string, error) {
+	src := bytes.TrimSpace(b)
+	var enc *base64.Encoding
+	switch {
+	case urlSafe && noPad:
+		enc = base64.RawURLEncoding
+	case urlSafe && !noPad:
+		enc = base64.URLEncoding
+	case !urlSafe && noPad:
+		enc = base64.RawStdEncoding
+	default:
+		enc = base64.StdEncoding
+	}
+	dst := make([]byte, enc.DecodedLen(len(src)))
+	n, err := enc.Decode(dst, src)
 	return string(dst[:n]), err
 }

--- a/models/base64_test.go
+++ b/models/base64_test.go
@@ -1,0 +1,59 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBase64Service_EncodeDecode(t *testing.T) {
+	s := Base64Service{}
+	cases := []struct {
+		name    string
+		input   string
+		urlSafe bool
+		noPad   bool
+	}{
+		{"std", "hello", false, false},
+		{"noPad", "hello", false, true},
+		{"urlSafe", "sample input", true, false},
+		{"urlSafeNoPad", "sample input", true, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enc := s.EncodeWith([]byte(tc.input), tc.urlSafe, tc.noPad)
+			if tc.urlSafe {
+				if strings.Contains(enc, "+") || strings.Contains(enc, "/") {
+					t.Fatalf("expected URL-safe output, got %q", enc)
+				}
+			}
+			dec, err := s.DecodeWith([]byte(enc), tc.urlSafe, tc.noPad)
+			if err != nil {
+				t.Fatalf("decode error: %v", err)
+			}
+			if dec != tc.input {
+				t.Fatalf("roundtrip mismatch: got %q want %q", dec, tc.input)
+			}
+		})
+	}
+}
+
+func TestBase64Service_Decode_Whitespace(t *testing.T) {
+	s := Base64Service{}
+	enc := s.Encode([]byte("hello"))
+	withWS := "  \n\t" + enc + "  \n"
+	dec, err := s.Decode([]byte(withWS))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dec != "hello" {
+		t.Fatalf("got %q want %q", dec, "hello")
+	}
+}
+
+func TestBase64Service_Decode_Invalid(t *testing.T) {
+	s := Base64Service{}
+	if _, err := s.Decode([]byte("!!!!")); err == nil {
+		t.Fatalf("expected error for invalid input")
+	}
+}

--- a/static/js/base64.js
+++ b/static/js/base64.js
@@ -1,0 +1,61 @@
+(function () {
+  function setButtonText(btn, text, timeout) {
+    if (!btn) return;
+    var original = btn.dataset.origText || btn.textContent || 'COPY';
+    btn.textContent = text;
+    clearTimeout(btn._copyTimer);
+    btn._copyTimer = setTimeout(function () {
+      btn.textContent = original;
+    }, timeout || 1200);
+  }
+
+  function copyToClipboard(btn) {
+    try {
+      var el = document.getElementById('b64-result');
+      var value = '';
+      if (el) {
+        value = (typeof el.value === 'string' && el.value.length ? el.value : (el.textContent || '')) || '';
+      }
+      navigator.clipboard.writeText(value)
+        .then(function () { setButtonText(btn, 'COPIED', 1200); })
+        .catch(function () { setButtonText(btn, 'COPY FAILED', 1500); });
+    } catch (e) {
+      setButtonText(btn, 'COPY FAILED', 1500);
+    }
+  }
+
+  function updateVisibility() {
+    var el = document.getElementById('b64-result');
+    var text = '';
+    if (el) {
+      text = (typeof el.value === 'string' && el.value.length ? el.value : (el.textContent || '')) || '';
+    }
+    var show = !!el && text.length > 0;
+    ['copy-top', 'copy-top-decode'].forEach(function (id) {
+      var btn = document.getElementById(id);
+      if (!btn) return;
+      if (show) { btn.classList.remove('hidden'); } else { btn.classList.add('hidden'); }
+    });
+  }
+
+  function attachHandlers() {
+    ['copy-top', 'copy-top-decode'].forEach(function (id) {
+      var btn = document.getElementById(id);
+      if (!btn) return;
+      if (!btn.dataset.origText) btn.dataset.origText = btn.textContent || 'COPY';
+      if (!btn._copyBound) {
+        btn.addEventListener('click', function () { copyToClipboard(btn); });
+        btn._copyBound = true;
+      }
+    });
+    updateVisibility();
+  }
+
+  document.addEventListener('DOMContentLoaded', attachHandlers);
+  document.addEventListener('htmx:afterSwap', function (evt) {
+    if (evt && evt.target && evt.target.id === 'response') {
+      attachHandlers();
+    }
+  });
+})();
+

--- a/templates/base.gohtml
+++ b/templates/base.gohtml
@@ -30,6 +30,7 @@
 {{ end }}
 {{ define "footer" }}
 <script src="/static/htmx.min.js"></script>
+<script src="/static/js/base64.js"></script>
 </body>
 </html>
 {{ end }}

--- a/templates/utils/base64/base64_error.gohtml
+++ b/templates/utils/base64/base64_error.gohtml
@@ -1,0 +1,4 @@
+<div class="mt-4 p-2 text-red-800 bg-red-100 border border-red-300 rounded">
+    {{ .Error }}
+    <div class="text-sm text-gray-600">Please check your input and try again.</div>
+</div>

--- a/templates/utils/base64/base64_response.gohtml
+++ b/templates/utils/base64/base64_response.gohtml
@@ -1,1 +1,0 @@
-<textarea name="str" class="mt-4 p-2" readonly="true" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13">{{ .Response }}</textarea>

--- a/templates/utils/base64/base64_response_decode.gohtml
+++ b/templates/utils/base64/base64_response_decode.gohtml
@@ -1,0 +1,1 @@
+<textarea id="b64-result" name="str" class="mt-2 p-2 bg-white text-gray-900 border border-gray-300 rounded" readonly="true" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13">{{ .Response }}</textarea>

--- a/templates/utils/base64/base64_response_encode.gohtml
+++ b/templates/utils/base64/base64_response_encode.gohtml
@@ -1,0 +1,2 @@
+<textarea id="b64-result" name="str" class="mt-2 p-2 bg-white text-gray-900 border border-gray-300 rounded" readonly="true" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13">{{ .Response }}</textarea>
+

--- a/templates/utils/base64/decode.gohtml
+++ b/templates/utils/base64/decode.gohtml
@@ -2,20 +2,29 @@
 
 <div class="container max-w-4xl mx-auto">
 	<div class="flex flex-col">
-		<div class="mt-24 lg:mt-52 w-full bg-slate-200">
+        <div class="mt-24 lg:mt-52 w-full bg-slate-200 border border-gray-300 rounded shadow-md">
 			<div class="m-8">
 				<div class="flex justify-around">
 					<span class="text-4xl font-bold">Base64 Decoding</span>
 					<input id="btnSubmit" value="SUBMIT" type="submit" form="form" class="bg-cyan-950 text-gray-300 hover:bg-gray-700 rounded-xl font-bold text-l p-2 border-4 border-green-700"></input>
 				</div>
-				<form id="form" class="flex flex-col" hx-post="/utils/base64/decode" hx-target="#response">
-					{{ csrfField }}
-					<textarea name="str" class="mt-8 p-2" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13"></textarea>
-				</form>
-				<div class="mt-4">
-					<p class="text-xl">Decoded:</p>
-					<div class="flex flex-col" id="response"></div>
-				</div>
+                <form id="form" class="flex flex-col" hx-post="/utils/base64/decode" hx-target="#response">
+                    {{ csrfField }}
+                    <div class="mt-4 flex gap-4 items-center">
+                        <label class="flex items-center gap-2"><input type="checkbox" name="urlSafe"> <span>URL-safe</span></label>
+                        <label class="flex items-center gap-2"><input type="checkbox" name="noPad"> <span>No padding</span></label>
+                    </div>
+                    <textarea name="str" class="mt-8 p-2 bg-white text-gray-900 border border-gray-300 rounded" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13"></textarea>
+                </form>
+                <div class="mt-4">
+                    <div class="flex items-center justify-between">
+                        <p class="text-xl">Decoded:</p>
+                        <button type="button" id="copy-top-decode"
+                            class="hidden bg-cyan-950 text-gray-300 hover:bg-gray-700 rounded-xl font-bold text-l p-2 border-4 border-green-700">COPY</button>
+                    </div>
+                    <div class="flex flex-col" id="response"></div>
+                </div>
+                
 			</div>
 		</div>
 	</div>

--- a/templates/utils/base64/encode.gohtml
+++ b/templates/utils/base64/encode.gohtml
@@ -2,20 +2,29 @@
 
 <div class="container max-w-4xl mx-auto">
 	<div class="flex flex-col">
-		<div class="mt-24 lg:mt-52 w-full bg-slate-200">
+        <div class="mt-24 lg:mt-52 w-full bg-slate-200 border border-gray-300 rounded shadow-md">
 			<div class="m-8">
 				<div class="flex justify-around">
 					<span class="text-4xl font-bold">Base64 Encoding</span>
 					<input id="btnSubmit" value="SUBMIT" type="submit" form="form" class="bg-cyan-950 text-gray-300 hover:bg-gray-700 rounded-xl font-bold text-l p-2 border-4 border-green-700"></input>
 				</div>
-				<form id="form" class="flex flex-col" hx-post="/utils/base64/encode" hx-target="#response">
-					{{ csrfField }}
-					<textarea name="str" class="mt-8 p-2" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13"></textarea>
-				</form>
-				<div class="mt-4">
-					<p class="text-xl">Encoded:</p>
-					<div class="flex flex-col" id="response"></div>
-				</div>
+                <form id="form" class="flex flex-col" hx-post="/utils/base64/encode" hx-target="#response">
+                    {{ csrfField }}
+                    <div class="mt-4 flex gap-4 items-center">
+                        <label class="flex items-center gap-2"><input type="checkbox" name="urlSafe"> <span>URL-safe</span></label>
+                        <label class="flex items-center gap-2"><input type="checkbox" name="noPad"> <span>No padding</span></label>
+                    </div>
+                    <textarea name="str" class="mt-8 p-2 bg-white text-gray-900 border border-gray-300 rounded" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13"></textarea>
+                </form>
+                <div class="mt-4">
+                    <div class="flex items-center justify-between">
+                        <p class="text-xl">Encoded:</p>
+                        <button type="button" id="copy-top"
+                            class="hidden bg-cyan-950 text-gray-300 hover:bg-gray-700 rounded-xl font-bold text-l p-2 border-4 border-green-700">COPY</button>
+                    </div>
+                    <div class="flex flex-col" id="response"></div>
+                </div>
+                
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This PR improves the Base64 utilities across correctness, UX, and API design, and adds tests.

What changed
- Decode error handling: return immediately to avoid mixed responses.
- Whitespace handling: trim input before decoding.
- Buffer sizing: use DecodedLen for decode buffers.
- Input guard: enforce 1024-char max on server.
- Inline error fragment: render HTML error partial in HTMX flows with proper status codes.
- JSON negotiation: honor `Accept: application/json` for both success and error paths.
- GET query endpoints: support `GET /utils/base64/encode?q=...` and `.../decode?q=...` returning text/plain or JSON.
- URL-safe & no-padding: add `urlSafe` and `noPad` options (GET/POST + service EncodeWith/DecodeWith).
- UI: white textareas, bordered panels, stronger shadow, top COPY buttons that show only after a result.
- JS: moved inline scripts to `static/js/base64.js` and included via base template.

Files of note
- controllers/base64.go, controllers/utils.go, cmd/bob/bob.go
- models/base64.go (plus new tests)
- templates/utils/base64/* (response partial split for encode/decode, error partial)
- static/js/base64.js (new)
- tests: controllers/base64_test.go, models/base64_test.go

Testing
- `go test ./...` passes for controllers and models.
- Manual: verify POST/GET HTML + JSON flows for encode/decode and UI COPY behavior.

Follow-ups (optional)
- Add security headers middleware (CSP, HSTS, X-Frame-Options, etc.).
- Validate `CSRF_KEY` length (>= 32 bytes) at startup.
- Switch to `http.Server` with read/write/idle timeouts.
