### PR TITLE
Add Tailwind CLI bootstrap for make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Tailwind generated styles
 static/styles.css
+tailwind/bin/
 
 # Test binary, built with `go test -c`
 *.test
@@ -20,6 +21,7 @@ static/styles.css
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
 
 # Go workspace file
 go.work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:latest as tailwind-builder
-WORKDIR /templates
-RUN npm init -y && \
-    npm install tailwindcss @tailwindcss/typography
+FROM node:20-alpine AS tailwind-builder
+ARG TAILWIND_VERSION=4.1.13
+WORKDIR /app
+RUN npm init -y \
+    && npm install tailwindcss@${TAILWIND_VERSION} @tailwindcss/typography
 COPY ./templates ./templates
-COPY ./tailwind/styles.css src/styles.css
-RUN npx tailwindcss -i src/styles.css -o /styles.css --minify
+COPY ./tailwind/styles.css ./tailwind/styles.css
+RUN npx tailwindcss -i ./tailwind/styles.css -o /styles.css --minify
 
 FROM golang:alpine AS builder
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: docker-build docker-publish docker-push local run tail-watch tail-prod 
+.PHONY: docker-build docker-publish docker-push local run tail-watch tail-prod
+
+TAILWIND_VERSION ?= 4.1.13
+TAILWIND_OS ?= linux
+TAILWIND_ARCH ?= x64
+TAILWIND_DOWNLOAD_URL := https://github.com/tailwindlabs/tailwindcss/releases/download/v$(TAILWIND_VERSION)/tailwindcss-$(TAILWIND_OS)-$(TAILWIND_ARCH)
+TAILWIND_BIN := ./tailwind/bin/tailwindcss
 
 local:
 	make -j 2 tail-watch run
@@ -17,8 +23,15 @@ docker-publish:
 run:
 	air
 
-tail-watch: 
-	tailwindcss -i ./tailwind/styles.css -o ./static/styles.css --watch
+tail-watch: tailwind-cli
+	$(TAILWIND_BIN) -i ./tailwind/styles.css -o ./static/styles.css --watch
 
-tail-prod: 
-	tailwindcss -i ./tailwind/styles.css -o ./static/styles.css --minify
+tail-prod: tailwind-cli
+	$(TAILWIND_BIN) -i ./tailwind/styles.css -o ./static/styles.css --minify
+
+tailwind-cli: $(TAILWIND_BIN)
+
+$(TAILWIND_BIN):
+	mkdir -p $(dir $(TAILWIND_BIN))
+	curl -sSL $(TAILWIND_DOWNLOAD_URL) -o $(TAILWIND_BIN)
+	chmod +x $(TAILWIND_BIN)


### PR DESCRIPTION
## Summary
- ensure the Tailwind make targets download the v4 CLI binary so local builds succeed without npm
- ignore the generated Tailwind CLI binary so it is not committed

## Testing
- make tail-prod

------
https://chatgpt.com/codex/tasks/task_e_68d81066a1908321b0bc725d62771f59