### PR TITLE
Add healthcheck endpoint for Swarm monitoring

### DIFF
--- a/Docker/traefik.yml
+++ b/Docker/traefik.yml
@@ -70,6 +70,12 @@ services:
   bob:
     image: 192.168.1.2:9000/bob:latest
     networks: [proxy]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     deploy:
       replicas: 3
       labels:

--- a/cmd/bob/bob.go
+++ b/cmd/bob/bob.go
@@ -65,6 +65,12 @@ func run(cfg models.Config) error {
 	r.HandleFunc("GET /", controllers.StaticHandler(
 		views.Must(views.ParseFS(templates.FS, "home/index.gohtml", "home/infocard.gohtml", "base.gohtml"))))
 
+	// Healthcheck
+	r.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
 	// Utils
 	r.HandleFunc("GET /utils", utilsController.Index)
 


### PR DESCRIPTION
## Summary
- add a lightweight /healthz handler for Swarm/Docker checks
- wire the Swarm stack healthcheck to call the new endpoint via wget

## Testing
- not run
