### PR TITLE
Ensure Docker builds use git short SHA tags

### DIFF
--- a/Docker/traefik.yml
+++ b/Docker/traefik.yml
@@ -68,7 +68,7 @@ services:
           - node.role == manager
 
   bob:
-    image: 192.168.1.2:9000/bob:latest
+    image: ${BOB_IMAGE?Set BOB_IMAGE to the full image reference (e.g. 192.168.1.2:9000/bob:abc123)}
     networks: [proxy]
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3000/healthz || exit 1"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: configure-image docker-build docker-publish docker-push ensure-image-tag local run tail-watch tail-prod
+.PHONY: configure-image docker-build docker-deploy docker-publish docker-push ensure-image-tag local run tail-watch tail-prod
 
 configure-image:
 	$(eval REGISTRY ?= 192.168.1.2:9000)
@@ -24,6 +24,9 @@ docker-push: ensure-image-tag
 
 docker-publish:
 	make docker-build docker-push
+
+docker-deploy: ensure-image-tag
+	BOB_IMAGE=$(IMAGE) docker stack deploy -c Docker/traefik.yml proxy
 
 run:
 	air


### PR DESCRIPTION
## Summary
- configure Docker image metadata in a dedicated make target
- guard docker build/push so they fail if git short SHA is missing
- tag and push images using only the SHA-derived reference

## Testing
- not run (docker not available in environment)