### PR TITLE
Align Base64 response styling with input

### DIFF
--- a/templates/utils/base64/base64_response.gohtml
+++ b/templates/utils/base64/base64_response.gohtml
@@ -3,4 +3,14 @@
         {{ .Error }}
 </div>
 {{ end }}
-<textarea name="str" class="mt-4 p-2" readonly="true" autocomplete="off" autofocus="true" cols="100" maxLength="1024" rows="13">{{ .Response }}</textarea>
+<textarea
+        name="str"
+        class="mt-4 p-4 bg-white border border-transparent rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-green-700 focus:border-green-700"
+        readonly="true"
+        autocomplete="off"
+        autofocus="true"
+        cols="100"
+        maxLength="1024"
+        rows="13">
+        {{ .Response }}
+</textarea>


### PR DESCRIPTION
## Summary
- update the Base64 response textarea to reuse the white background, border, and green focus styles
- retain the existing error alert for Base64 operations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec0eb7feac83218bf7d527488ec113