### PR TITLE
Fix Safari utils page load by adjusting HTML response headers

### DIFF
--- a/controllers/base64.go
+++ b/controllers/base64.go
@@ -18,7 +18,7 @@ type base64Response struct {
 }
 
 func (u *Utils) Encode(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/html")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	encoded, err := u.Base64Service.Encode([]byte(r.PostFormValue("str")), r.PostFormValue("encoding"))
 	if err != nil {
 		message := "The selected Base64 variant is not supported."
@@ -34,7 +34,7 @@ func (u *Utils) Encode(w http.ResponseWriter, r *http.Request) {
 }
 
 func (u *Utils) Decode(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/html")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	str, err := u.Base64Service.Decode([]byte(r.PostFormValue("str")), r.PostFormValue("encoding"))
 	if err != nil {

--- a/controllers/base64_test.go
+++ b/controllers/base64_test.go
@@ -53,8 +53,8 @@ func TestUtilsEncodeWritesEncodedString(t *testing.T) {
 		t.Fatalf("Encode status code = %d, want %d", rr.Code, http.StatusOK)
 	}
 
-	if got := rr.Header().Get("Content-Type"); got != "text/html" {
-		t.Fatalf("Content-Type header = %q, want %q", got, "text/html")
+	if got := rr.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("Content-Type header = %q, want %q", got, "text/html; charset=utf-8")
 	}
 
 	body := rr.Body.String()

--- a/views/page_test.go
+++ b/views/page_test.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -32,11 +33,15 @@ func TestParseFSReturnsPageWithCategory(t *testing.T) {
 		t.Fatalf("Execute returned status %d, want %d", rr.Code, http.StatusOK)
 	}
 
-	if got := rr.Header().Get("Content-Type"); got != "text/html" {
-		t.Fatalf("Execute set Content-Type %q, want %q", got, "text/html")
+	body := rr.Body.String()
+	if got := rr.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("Execute set Content-Type %q, want %q", got, "text/html; charset=utf-8")
 	}
 
-	body := rr.Body.String()
+	if got := rr.Header().Get("Content-Length"); got != strconv.Itoa(len(body)) {
+		t.Fatalf("Execute set Content-Length %q, want %q", got, strconv.Itoa(len(body)))
+	}
+
 	if !strings.Contains(body, "Category: blog") {
 		t.Fatalf("Execute rendered %q, want to contain %q", body, "Category: blog")
 	}
@@ -74,5 +79,39 @@ func TestPageExecuteHandlesTemplateErrors(t *testing.T) {
 	body := rr.Body.String()
 	if !strings.Contains(body, "There was an error executing the template.") {
 		t.Fatalf("Execute rendered %q, want error message", body)
+	}
+}
+
+func TestPageExecuteHandlesHEADRequests(t *testing.T) {
+	t.Parallel()
+
+	const tmplBody = "Hello, world!"
+
+	fsys := fstest.MapFS{
+		"utils/index.tmpl": {
+			Data: []byte(tmplBody),
+		},
+	}
+
+	page, err := ParseFS(fsys, "utils/index.tmpl")
+	if err != nil {
+		t.Fatalf("ParseFS returned unexpected error: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodHead, "/utils", nil)
+	rr := httptest.NewRecorder()
+
+	page.Execute(rr, req, nil)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Execute returned status %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	if rr.Body.Len() != 0 {
+		t.Fatalf("Execute wrote %d bytes to HEAD response body, want 0", rr.Body.Len())
+	}
+
+	if got := rr.Header().Get("Content-Length"); got != strconv.Itoa(len(tmplBody)) {
+		t.Fatalf("Execute set Content-Length %q, want %q", got, strconv.Itoa(len(tmplBody)))
 	}
 }


### PR DESCRIPTION
## Summary
- set HTML responses to include a charset, explicit Content-Length, and skip the body for HEAD requests to avoid Safari zero-byte loads
- update the Base64 controller handlers to return the same Content-Type header as the shared view helper
- extend view and controller tests to cover the new headers and HEAD behavior

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68fc26920c6c8321a44b580ab154eb79