### PR TITLE
chore: update Go and harden response headers

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@ COPY ./templates ./templates
 COPY ./tailwind/styles.css src/styles.css
 RUN npx @tailwindcss/cli -i src/styles.css -o /styles.css --minify
 
-FROM golang:1.25.10-alpine3.23 AS builder
+FROM golang:1.26.3-alpine3.23 AS builder
 ARG VERSION=dev
 ARG REVISION=unknown
 WORKDIR /app

--- a/cmd/bob/bob.go
+++ b/cmd/bob/bob.go
@@ -82,7 +82,7 @@ func newHandler(cfg models.Config, logger *slog.Logger) http.Handler {
 
 	var handler http.Handler = r
 	handler = middleware.CSRF(cfg.CSRF.Key, cfg.CSRF.Secure)(handler)
-	handler = middleware.SecureHeaders(handler)
+	handler = middleware.SecureHeaders(cfg.CSRF.Secure)(handler)
 	handler = middleware.RequestLogger(logger)(handler)
 
 	return handler

--- a/controllers/middleware/secure_headers.go
+++ b/controllers/middleware/secure_headers.go
@@ -7,12 +7,25 @@ const contentSecurityPolicy = "default-src 'self'; " +
 	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
 	"font-src 'self' https://fonts.gstatic.com; " +
 	"img-src 'self'; " +
-	"connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;"
+	"connect-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com; " +
+	"object-src 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'; " +
+	"frame-ancestors 'none';"
 
 // SecureHeaders adds HTTP response headers that harden browser security for the site.
-func SecureHeaders(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
-		next.ServeHTTP(w, r)
-	})
+func SecureHeaders(hsts bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			w.Header().Set("Permissions-Policy", "geolocation=(), microphone=(), camera=(), payment=()")
+			if hsts {
+				w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/controllers/middleware/secure_headers_test.go
+++ b/controllers/middleware/secure_headers_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestSecureHeadersAddsCSP(t *testing.T) {
+func TestSecureHeadersAddsBrowserHardeningHeaders(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -14,9 +14,39 @@ func TestSecureHeadersAddsCSP(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	SecureHeaders(handler).ServeHTTP(rr, req)
+	SecureHeaders(false)(handler).ServeHTTP(rr, req)
 
 	if got := rr.Header().Get("Content-Security-Policy"); got != contentSecurityPolicy {
 		t.Fatalf("Content-Security-Policy header = %q, want %q", got, contentSecurityPolicy)
+	}
+	if got := rr.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options header = %q, want nosniff", got)
+	}
+	if got := rr.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options header = %q, want DENY", got)
+	}
+	if got := rr.Header().Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
+		t.Fatalf("Referrer-Policy header = %q, want strict-origin-when-cross-origin", got)
+	}
+	if got := rr.Header().Get("Permissions-Policy"); got == "" {
+		t.Fatal("Permissions-Policy header is empty")
+	}
+	if got := rr.Header().Get("Strict-Transport-Security"); got != "" {
+		t.Fatalf("Strict-Transport-Security header = %q, want empty for non-HSTS middleware", got)
+	}
+}
+
+func TestSecureHeadersAddsHSTSWhenEnabled(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	SecureHeaders(true)(handler).ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Strict-Transport-Security"); got != "max-age=31536000; includeSubDomains" {
+		t.Fatalf("Strict-Transport-Security header = %q, want production HSTS", got)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DryWaters/bitofbytes
 
-go 1.25.10
+go 1.26.3
 
 require (
 	github.com/gorilla/csrf v1.7.3


### PR DESCRIPTION
## Summary
- update Go module and Docker builder to 1.26.3
- add nosniff, referrer, frame, CSP, permissions, and production HSTS headers
- keep required font, inline style, local script, and Umami allowances

## Tests
- GOTOOLCHAIN=go1.26.3 go test ./...
- GOTOOLCHAIN=go1.26.3 govulncheck ./...
- GOTOOLCHAIN=go1.26.3 go build ./...