### PR TITLE
test: assert exact Permissions-Policy header

### DIFF
--- a/controllers/middleware/secure_headers_test.go
+++ b/controllers/middleware/secure_headers_test.go
@@ -28,8 +28,8 @@ func TestSecureHeadersAddsBrowserHardeningHeaders(t *testing.T) {
 	if got := rr.Header().Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
 		t.Fatalf("Referrer-Policy header = %q, want strict-origin-when-cross-origin", got)
 	}
-	if got := rr.Header().Get("Permissions-Policy"); got == "" {
-		t.Fatal("Permissions-Policy header is empty")
+	if got := rr.Header().Get("Permissions-Policy"); got != "geolocation=(), microphone=(), camera=(), payment=()" {
+		t.Fatalf("Permissions-Policy header = %q, want geolocation=(), microphone=(), camera=(), payment=()", got)
 	}
 	if got := rr.Header().Get("Strict-Transport-Security"); got != "" {
 		t.Fatalf("Strict-Transport-Security header = %q, want empty for non-HSTS middleware", got)


### PR DESCRIPTION
## Summary
- tighten the header middleware test to assert the exact Permissions-Policy value
- leave HSTS preload out intentionally because it is a long-term browser preload commitment

## Tests
- GOTOOLCHAIN=go1.26.3 go test ./...
- GOTOOLCHAIN=go1.26.3 govulncheck ./...
- GOTOOLCHAIN=go1.26.3 go build ./...