### PR TITLE
Gate Umami tracking to production host

### DIFF
--- a/templates/base.gohtml
+++ b/templates/base.gohtml
@@ -45,12 +45,19 @@
 {{ define "footer" }}
 </div>
 <script defer src="/static/nav-menu.js"></script>
-<script
-  async
-  defer
-  data-website-id="16dc0a19-c8ad-4ede-a122-c0986d542941"
-  src="https://bitofbytes.io/umami/script.js"
-></script>
+<script>
+  (function () {
+    if (window.location.hostname !== "bitofbytes.io") {
+      return;
+    }
+
+    var script = document.createElement("script");
+    script.async = true;
+    script.dataset.websiteId = "16dc0a19-c8ad-4ede-a122-c0986d542941";
+    script.src = "https://bitofbytes.io/umami/script.js";
+    document.head.appendChild(script);
+  })();
+</script>
 </body>
 </html>
 {{ end }}


### PR DESCRIPTION
## Summary
- Replaces the existing unconditional BitOfBytes Umami script tag with a production-host gate.
- Local development pages no longer load or report to the production Umami website.

## Tests
- `go test ./...`

Review gate: do not merge until CI is green and code review has happened.