### PR TITLE
Load Umami gate from CSP-safe script

### DIFF
--- a/static/umami-loader.js
+++ b/static/umami-loader.js
@@ -1,0 +1,11 @@
+(function () {
+  if (window.location.hostname !== "bitofbytes.io") {
+    return;
+  }
+
+  var script = document.createElement("script");
+  script.async = true;
+  script.dataset.websiteId = "16dc0a19-c8ad-4ede-a122-c0986d542941";
+  script.src = "https://bitofbytes.io/umami/script.js";
+  document.head.appendChild(script);
+})();

--- a/templates/base.gohtml
+++ b/templates/base.gohtml
@@ -45,19 +45,7 @@
 {{ define "footer" }}
 </div>
 <script defer src="/static/nav-menu.js"></script>
-<script>
-  (function () {
-    if (window.location.hostname !== "bitofbytes.io") {
-      return;
-    }
-
-    var script = document.createElement("script");
-    script.async = true;
-    script.dataset.websiteId = "16dc0a19-c8ad-4ede-a122-c0986d542941";
-    script.src = "https://bitofbytes.io/umami/script.js";
-    document.head.appendChild(script);
-  })();
-</script>
+<script defer src="/static/umami-loader.js"></script>
 </body>
 </html>
 {{ end }}


### PR DESCRIPTION
## Summary
- Moves the BitOfBytes production-only Umami gate into /static/umami-loader.js.
- Keeps local hosts from loading production tracking while satisfying the existing script-src self CSP.

## Tests
- `go test ./...`