### PR TITLE
[codex] Add Tailscale deployment networking

### DIFF
--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-trigger:
     runs-on: ubuntu-24.04-arm
@@ -21,6 +25,14 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          audience: ${{ secrets.TS_AUDIENCE }}
+          tags: tag:ci
+          ping: ${{ vars.MANAGER_HOST }}
 
       - name: Log in to registry
         uses: docker/login-action@v4

--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -3,12 +3,11 @@ on:
   push:
     branches: [ main ]
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   build-and-trigger:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-24.04-arm
     environment:
       name: crystal1
@@ -27,7 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           audience: ${{ secrets.TS_AUDIENCE }}

--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       IMAGE_REG: ${{ vars.IMAGE_REG }}
       IMAGE_REPO: ${{ vars.IMAGE_REPO }}
+      MANAGER_HOST: ${{ vars.MANAGER_HOST }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -29,9 +30,9 @@ jobs:
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          audience: ${{ secrets.TS_AUDIENCE }}
+          audience: ${{ vars.TS_AUDIENCE }}
           tags: tag:ci
-          ping: ${{ vars.MANAGER_HOST }}
+          ping: ${{ env.MANAGER_HOST }}
 
       - name: Log in to registry
         uses: docker/login-action@v4
@@ -75,7 +76,7 @@ jobs:
 
       - name: Push main to local bare repo (trigger hook)
         env:
-          MANAGER: ${{ vars.MANAGER_HOST }}
+          MANAGER: ${{ env.MANAGER_HOST }}
         run: |
           set -euo pipefail
           git remote add local "ssh://git@${MANAGER}/srv/git/bob-ci.git"

--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -23,9 +23,6 @@ jobs:
         id: meta
         run: echo "TAG=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
       - name: Connect to Tailscale
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8
         with:
@@ -33,6 +30,9 @@ jobs:
           audience: ${{ vars.TS_AUDIENCE }}
           tags: tag:ci
           ping: ${{ env.MANAGER_HOST }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to registry
         uses: docker/login-action@v4


### PR DESCRIPTION
## Summary
- Adds `tailscale/github-action@v4` before Docker registry login and deploy SSH.
- Grants `contents: read` and `id-token: write` for Tailscale workload identity.
- Uses `TS_OAUTH_CLIENT_ID`, `TS_AUDIENCE`, and `MANAGER_HOST` from the `crystal1` GitHub environment.

## Validation
- `git diff --check`
- Ruby YAML parse of workflow file

## Operational notes
- Merge after the `home_swarm` Traefik/DNS changes are reviewed and deployed.
- Public 22 and 9000 port forwards should stay enabled until a main-branch deploy succeeds through Tailscale.