### PR TITLE
[codex] Route registry through Tailscale service

### DIFF
--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
 
       - name: Log in to registry
         uses: docker/login-action@v4

--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -31,25 +31,26 @@ jobs:
           tags: tag:ci
           ping: ${{ env.MANAGER_HOST }}
 
-      - name: Route registry over Tailscale
+      - name: Verify registry Tailscale route
         run: |
           set -euo pipefail
-          registry_host="${IMAGE_REG%%/*}"
-          registry_host="${registry_host%%:*}"
-          manager_ip="$(getent ahostsv4 "${MANAGER_HOST}" | awk '{print $1; exit}')"
-          if [[ -z "${registry_host}" || -z "${manager_ip}" ]]; then
-            echo "Unable to resolve registry host or manager Tailscale IP" >&2
+          registry_endpoint="${IMAGE_REG%%/*}"
+          registry_host="${registry_endpoint%%:*}"
+          registry_ip="$(getent ahostsv4 "${registry_host}" | awk '{print $1; exit}')"
+          if [[ -z "${registry_host}" || -z "${registry_ip}" ]]; then
+            echo "Unable to resolve registry host over Tailscale" >&2
             exit 1
           fi
-          if [[ ! "${manager_ip}" =~ ^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            echo "Resolved manager IP ${manager_ip} is not in the Tailscale CGNAT range" >&2
+          if [[ ! "${registry_ip}" =~ ^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            echo "Resolved registry IP ${registry_ip} is not in the Tailscale CGNAT range" >&2
             exit 1
           fi
-          echo "Routing ${registry_host} to ${manager_ip} over Tailscale"
-          escaped_registry_host="${registry_host//./\\.}"
-          sudo sed -i.bak "/[[:space:]]${escaped_registry_host}$/d" /etc/hosts
-          echo "${manager_ip} ${registry_host}" | sudo tee -a /etc/hosts
-          getent hosts "${registry_host}"
+          status="$(curl -sS -o /dev/null -w '%{http_code}' "https://${registry_endpoint}/v2/")"
+          if [[ "${status}" != "200" && "${status}" != "401" ]]; then
+            echo "Registry returned unexpected HTTP status ${status}" >&2
+            exit 1
+          fi
+          echo "Registry ${registry_endpoint} resolved to ${registry_ip} and returned HTTP ${status}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: configure-image build-github docker-build-push-github docker-build docker-publish docker-push ensure-image-tag local run tail-watch tail-prod
 
 configure-image:
-	$(eval REGISTRY ?= registry.bitofbytes.io)
+	$(eval REGISTRY ?= registry.tail209cfc.ts.net)
 	$(eval IMAGE_NAME ?= $(REGISTRY)/bob)
 	$(eval SHORT_SHA := $(shell git rev-parse --short HEAD))
 	$(eval REVISION ?= $(shell git rev-parse HEAD 2>/dev/null))

--- a/docs/security/secrets.md
+++ b/docs/security/secrets.md
@@ -25,7 +25,7 @@ value cannot be read. Example service definition:
 ```sh
 docker service create \
   --secret source=csrf_key,target=csrf_key \
-  registry.bitofbytes.io/bob:latest
+  registry.tail209cfc.ts.net/bob:latest
 ```
 
 ### Creating the CSRF secret


### PR DESCRIPTION
## Summary
- remove the temporary `/etc/hosts` override that pinned the registry hostname to `crystal1`
- let `registry.tail209cfc.ts.net` resolve normally through the Tailscale Service after the runner joins Tailscale
- add a pre-login registry check that requires the registry hostname to resolve into Tailscale CGNAT space and `/v2/` to respond over HTTPS
- update local registry defaults/docs from `registry.bitofbytes.io` to `registry.tail209cfc.ts.net` where this repo hard-coded the old host

## Validation
- parsed the GitHub Actions workflow YAML with Ruby YAML
- ran `git diff --check`

## Deployment notes
This should be merged alongside the matching `home_swarm` change that exposes the registry through a local `tailserve-registry` Traefik entrypoint. After merge, set `IMAGE_REG=registry.tail209cfc.ts.net` for this repo before relying on new pushes.
