### PR TITLE
Standardize request log levels

### DIFF
--- a/controllers/middleware/logging.go
+++ b/controllers/middleware/logging.go
@@ -19,16 +19,27 @@ func RequestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 			next.ServeHTTP(lrw, r)
 
 			duration := time.Since(start)
-			logger.Info("request completed",
-				"method", r.Method,
-				"path", r.URL.Path,
-				"status", lrw.Status(),
-				"duration", duration,
-				"bytes", lrw.BytesWritten(),
-				"client_ip", clientIP(r),
-				"forwarded_for", forwardedFor(r),
+			logger.LogAttrs(r.Context(), requestLogLevel(lrw.Status()), "http request",
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", lrw.Status()),
+				slog.Duration("duration", duration),
+				slog.Int64("bytes", lrw.BytesWritten()),
+				slog.String("client_ip", clientIP(r)),
+				slog.String("forwarded_for", forwardedFor(r)),
 			)
 		})
+	}
+}
+
+func requestLogLevel(status int) slog.Level {
+	switch {
+	case status >= http.StatusInternalServerError:
+		return slog.LevelError
+	case status >= http.StatusBadRequest:
+		return slog.LevelWarn
+	default:
+		return slog.LevelDebug
 	}
 }
 

--- a/controllers/middleware/logging_test.go
+++ b/controllers/middleware/logging_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRequestLoggerEmitsDebugAccessLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	handler := RequestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	logs := buf.String()
+	if !strings.Contains(logs, "http request") {
+		t.Fatalf("log output = %q, want request log", logs)
+	}
+	if !strings.Contains(logs, "path=/healthz") {
+		t.Fatalf("log output = %q, want path", logs)
+	}
+	if !strings.Contains(logs, "status=204") {
+		t.Fatalf("log output = %q, want status", logs)
+	}
+	if !strings.Contains(logs, "level=DEBUG") {
+		t.Fatalf("log output = %q, want debug level", logs)
+	}
+}
+
+func TestRequestLoggerElevatesClientAndServerErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		code  int
+		level string
+	}{
+		{name: "client error", code: http.StatusNotFound, level: "level=WARN"},
+		{name: "server error", code: http.StatusInternalServerError, level: "level=ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			handler := RequestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.code)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if logs := buf.String(); !strings.Contains(logs, tt.level) {
+				t.Fatalf("log output = %q, want %s", logs, tt.level)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- change request logging to use the shared `http request` message
- keep successful request access logs at DEBUG
- surface 4xx request logs at WARN and 5xx request logs at ERROR
- add middleware tests for request log levels

## Validation
- go test ./...
