### PR TITLE
[codex] Update Go to 1.26.4

### DIFF
--- a/.github/workflows/build-push-and-trigger.yml
+++ b/.github/workflows/build-push-and-trigger.yml
@@ -16,7 +16,7 @@ jobs:
       IMAGE_REPO: ${{ vars.IMAGE_REPO }}
       MANAGER_HOST: ${{ vars.MANAGER_HOST }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Derive TAG

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,7 +7,7 @@ COPY ./templates ./templates
 COPY ./tailwind/styles.css src/styles.css
 RUN npx @tailwindcss/cli -i src/styles.css -o /styles.css --minify
 
-FROM golang:1.26.3-alpine3.23 AS builder
+FROM golang:1.26.4-alpine3.23 AS builder
 ARG VERSION=dev
 ARG REVISION=unknown
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DryWaters/bitofbytes
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gorilla/csrf v1.7.3


### PR DESCRIPTION
## Summary
- bump go.mod to Go 1.26.4
- update the Docker builder image to golang:1.26.4-alpine3.23
- update GitHub Actions checkout to the current major

## Validation
- PATH=/Users/daniel/sdk/go1.26.4/bin:/Users/daniel/go/bin:$PATH go test ./...
- PATH=/Users/daniel/sdk/go1.26.4/bin:/Users/daniel/go/bin:$PATH go build ./...
- PATH=/Users/daniel/sdk/go1.26.4/bin:/Users/daniel/go/bin:$PATH govulncheck ./... (0 reachable vulnerabilities; gorilla/csrf package finding has no fixed version and no called vulnerable symbols)
- docker build --pull -f Docker/Dockerfile -t codex/bitofbytes:go1.26.4 .