### PR TITLE
[codex] Serve root icon aliases

### DIFF
--- a/cmd/bob/bob.go
+++ b/cmd/bob/bob.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/DryWaters/bitofbytes/controllers"
@@ -59,6 +60,10 @@ func run(cfg models.Config, logger *slog.Logger) error {
 }
 
 func newHandler(cfg models.Config, logger *slog.Logger) http.Handler {
+	return newHandlerWithStaticDir(cfg, logger, "static")
+}
+
+func newHandlerWithStaticDir(cfg models.Config, logger *slog.Logger, staticDir string) http.Handler {
 	portfolio := controllers.Portfolio{
 		Projects: models.Projects(),
 		Templates: controllers.PortfolioTemplates{
@@ -76,8 +81,13 @@ func newHandler(cfg models.Config, logger *slog.Logger) http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+	// Support browser default icon discovery paths in addition to the template's
+	// explicit /static/... icon links.
+	r.HandleFunc("GET /favicon.ico", serveStaticFile(staticDir, "favicon.ico"))
+	r.HandleFunc("GET /apple-touch-icon.png", serveStaticFile(staticDir, "apple-touch-icon.png"))
+	r.HandleFunc("GET /apple-touch-icon-precomposed.png", serveStaticFile(staticDir, "apple-touch-icon.png"))
 
-	staticHandler := http.FileServer(http.Dir("static"))
+	staticHandler := http.FileServer(http.Dir(staticDir))
 	r.Handle("GET /static/", http.StripPrefix("/static/", staticHandler))
 
 	var handler http.Handler = r
@@ -86,4 +96,10 @@ func newHandler(cfg models.Config, logger *slog.Logger) http.Handler {
 	handler = middleware.RequestLogger(logger)(handler)
 
 	return handler
+}
+
+func serveStaticFile(staticDir string, name string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, filepath.Join(staticDir, name))
+	}
 }

--- a/cmd/bob/bob_test.go
+++ b/cmd/bob/bob_test.go
@@ -18,7 +18,7 @@ func newTestHandler() http.Handler {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	return newHandler(cfg, logger)
+	return newHandlerWithStaticDir(cfg, logger, "../../static")
 }
 
 func TestRoutesRenderCurrentSiteSurface(t *testing.T) {
@@ -70,6 +70,43 @@ func TestRemovedRoutesReturnNotFound(t *testing.T) {
 
 		if rr.Code != http.StatusNotFound {
 			t.Fatalf("%s status code = %d, want %d", path, rr.Code, http.StatusNotFound)
+		}
+	}
+}
+
+func TestIconRoutesServeStaticFiles(t *testing.T) {
+	t.Parallel()
+
+	handler := newTestHandler()
+
+	tests := []struct {
+		path            string
+		wantContentType string
+	}{
+		{path: "/favicon.ico", wantContentType: "image/x-icon"},
+		{path: "/apple-touch-icon.png", wantContentType: "image/png"},
+		{path: "/apple-touch-icon-precomposed.png", wantContentType: "image/png"},
+		{path: "/static/favicon.ico", wantContentType: "image/x-icon"},
+		{path: "/static/favicon.svg", wantContentType: "image/svg+xml"},
+		{path: "/static/favicon-32x32.png", wantContentType: "image/png"},
+		{path: "/static/favicon-16x16.png", wantContentType: "image/png"},
+		{path: "/static/apple-touch-icon.png", wantContentType: "image/png"},
+	}
+
+	for _, tt := range tests {
+		req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s status code = %d, want %d", tt.path, rr.Code, http.StatusOK)
+		}
+		if contentType := rr.Header().Get("Content-Type"); !strings.HasPrefix(contentType, tt.wantContentType) {
+			t.Fatalf("%s Content-Type = %q, want prefix %q", tt.path, contentType, tt.wantContentType)
+		}
+		if rr.Body.Len() == 0 {
+			t.Fatalf("%s served an empty body", tt.path)
 		}
 	}
 }

--- a/cmd/bob/bob_test.go
+++ b/cmd/bob/bob_test.go
@@ -94,20 +94,22 @@ func TestIconRoutesServeStaticFiles(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		req := httptest.NewRequest(http.MethodGet, tt.path, nil)
-		rr := httptest.NewRecorder()
+		t.Run(tt.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rr := httptest.NewRecorder()
 
-		handler.ServeHTTP(rr, req)
+			handler.ServeHTTP(rr, req)
 
-		if rr.Code != http.StatusOK {
-			t.Fatalf("%s status code = %d, want %d", tt.path, rr.Code, http.StatusOK)
-		}
-		if contentType := rr.Header().Get("Content-Type"); !strings.HasPrefix(contentType, tt.wantContentType) {
-			t.Fatalf("%s Content-Type = %q, want prefix %q", tt.path, contentType, tt.wantContentType)
-		}
-		if rr.Body.Len() == 0 {
-			t.Fatalf("%s served an empty body", tt.path)
-		}
+			if rr.Code != http.StatusOK {
+				t.Errorf("status code = %d, want %d", rr.Code, http.StatusOK)
+			}
+			if contentType := rr.Header().Get("Content-Type"); !strings.HasPrefix(contentType, tt.wantContentType) {
+				t.Errorf("Content-Type = %q, want prefix %q", contentType, tt.wantContentType)
+			}
+			if rr.Body.Len() == 0 {
+				t.Errorf("served an empty body")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Serve `/favicon.ico`, `/apple-touch-icon.png`, and `/apple-touch-icon-precomposed.png` from the existing static icon assets.
- Keep the existing `/static/...` asset route intact and covered by tests.

## Why
Browsers and iOS clients probe root-level icon paths even though the template advertises `/static/...` URLs. Those probes were generating 404s despite the icon files existing in the repo.

## Validation
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static assets now served from a configurable directory instead of hardcoded path
  * Added explicit routes for browser icons (favicon.ico, apple-touch-icon.png, apple-touch-icon-precomposed.png)

* **Tests**
  * Added tests verifying icon routes serve files with correct content types and status codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->